### PR TITLE
Show two months in singleDate mode

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -280,6 +280,14 @@ $(function()
 		singleDate : true,
 		showShortcuts: false 
 	});
+	
+	$('#date-range13-2').dateRangePicker(
+	{
+		autoClose: true,
+		singleDate : true,
+		showShortcuts: false,
+		singleMonth: true
+	});
 
 	$('#date-range14').dateRangePicker(
 	{

--- a/index.html
+++ b/index.html
@@ -354,6 +354,20 @@
 	showShortcuts: false
 }				</pre>
 			</div>
+			
+			
+			<div class="demo">
+				Single Date mode with single month: <input id="date-range13-2" size="40" value="2015-03-01">
+				<a href="#" class="show-option">Show Config</a>
+				<pre class="options">
+{
+	autoClose: true,
+	singleDate : true,
+	showShortcuts: false,
+	singleMonth: true
+}				</pre>
+			</div>
+			
 
 			<div class="demo">
 				 Batch mode ( week ): <input id="date-range14" size="60" value="">
@@ -759,7 +773,8 @@ $('#date-range16-reset').click(function(evt)
 	</i>
 
 <b>singleDate (Boolean)</b>
-	<i>choose a single date instead of a date range.
+	<i>choose a single date instead of a date range. If `singleMonth` option is set to true it will show
+	only one month instead of two months.
 	</i>
 
 <b>batchMode (false / 'week' / 'month')</b>

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -1680,7 +1680,10 @@
 
 			}
 			showMonth(date1,'month1');
-			//showMonth(date2,'month2');
+			if (opt.singleMonth !== true) {
+      				date2 = nextMonth(date1);
+      				showMonth(date2, 'month2');
+    			}
 			showGap();
 			showSelectedInfo();
 			autoclose();

--- a/jquery.daterangepicker.js
+++ b/jquery.daterangepicker.js
@@ -594,8 +594,6 @@
 		if (opt.singleMonth == 'auto') opt.singleMonth = $(window).width() < 480;
 		if (opt.singleMonth) opt.stickyMonths = false;
 
-		if (opt.singleDate) opt.singleMonth = true;
-
 		if (!opt.showTopbar) opt.autoClose = true;
 
 		if (opt.startDate && typeof opt.startDate == 'string') opt.startDate = moment(opt.startDate,opt.format).toDate();
@@ -2063,7 +2061,7 @@
 
 		function hasMonth2()
 		{
-			return ( !opt.singleDate && !opt.singleMonth);
+			return (!opt.singleMonth);
 		}
 
 		function attributesCallbacks(initialObject,callbacksArray,today)


### PR DESCRIPTION
Allow show the view of two months when the singleDate option is selected. Thus avoiding extra clicks to select a day for the end user. For example, It's 31th March and you need select a day in the next month. For achieve this you need 2 clicks showing one month. With this modification only one click is necessary.
